### PR TITLE
chore: fix all ruff lint errors (122 issues)

### DIFF
--- a/mcp-extension/src/slopesniper_api/server.py
+++ b/mcp-extension/src/slopesniper_api/server.py
@@ -7,32 +7,29 @@ Deploy this to your server and call via WebFetch from Cowork.
 from __future__ import annotations
 
 import os
-from typing import Optional
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException, Depends, Header
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 # Import skill functions
 from slopesniper_skill import (
-    solana_get_price,
-    solana_search_token,
+    get_status,
+    get_strategy,
+    get_watchlist,
+    list_strategies,
+    quick_trade,
+    scan_opportunities,
+    set_strategy,
     solana_check_token,
+    solana_get_price,
     solana_get_wallet,
     solana_quote,
+    solana_search_token,
     solana_swap_confirm,
-    quick_trade,
-    get_status,
-    setup_wallet,
-    set_strategy,
-    get_strategy,
-    list_strategies,
-    scan_opportunities,
     watch_token,
-    get_watchlist,
 )
-
 
 # API Key authentication
 API_KEY = os.environ.get("SLOPESNIPER_API_KEY", "")
@@ -93,11 +90,11 @@ class ConfirmRequest(BaseModel):
 
 
 class StrategyRequest(BaseModel):
-    strategy: Optional[str] = None
-    max_trade_usd: Optional[float] = None
-    auto_execute_under_usd: Optional[float] = None
-    slippage_bps: Optional[int] = None
-    require_rugcheck: Optional[bool] = None
+    strategy: str | None = None
+    max_trade_usd: float | None = None
+    auto_execute_under_usd: float | None = None
+    slippage_bps: int | None = None
+    require_rugcheck: bool | None = None
 
 
 class WatchRequest(BaseModel):
@@ -218,7 +215,7 @@ async def api_check_token(mint: str):
 
 
 @app.get("/wallet", dependencies=[Depends(verify_api_key)])
-async def api_get_wallet(address: Optional[str] = None):
+async def api_get_wallet(address: str | None = None):
     """Get wallet balances."""
     return await solana_get_wallet(address)
 

--- a/mcp-extension/src/slopesniper_mcp/server.py
+++ b/mcp-extension/src/slopesniper_mcp/server.py
@@ -10,6 +10,46 @@ from __future__ import annotations
 from mcp.server.fastmcp import FastMCP
 
 from slopesniper_skill import (
+    export_wallet as skill_export_wallet,
+)
+from slopesniper_skill import (
+    # PnL tracking
+    get_portfolio_pnl as skill_get_portfolio_pnl,
+)
+from slopesniper_skill import (
+    # Onboarding
+    get_status as skill_get_status,
+)
+from slopesniper_skill import (
+    get_strategy as skill_get_strategy,
+)
+from slopesniper_skill import (
+    get_trade_history as skill_get_trade_history,
+)
+from slopesniper_skill import (
+    get_watchlist as skill_get_watchlist,
+)
+from slopesniper_skill import (
+    list_strategies as skill_list_strategies,
+)
+from slopesniper_skill import (
+    quick_trade as skill_quick_trade,
+)
+from slopesniper_skill import (
+    remove_from_watchlist as skill_remove_from_watchlist,
+)
+from slopesniper_skill import (
+    # Scanner
+    scan_opportunities as skill_scan_opportunities,
+)
+from slopesniper_skill import (
+    # Strategies
+    set_strategy as skill_set_strategy,
+)
+from slopesniper_skill import (
+    setup_wallet as skill_setup_wallet,
+)
+from slopesniper_skill import (
     # Core trading
     solana_check_token,
     solana_get_price,
@@ -17,30 +57,16 @@ from slopesniper_skill import (
     solana_quote,
     solana_search_token,
     solana_swap_confirm,
-    quick_trade as skill_quick_trade,
-    # Onboarding
-    get_status as skill_get_status,
-    setup_wallet as skill_setup_wallet,
-    export_wallet as skill_export_wallet,
-    # Strategies
-    set_strategy as skill_set_strategy,
-    get_strategy as skill_get_strategy,
-    list_strategies as skill_list_strategies,
-    # PnL tracking
-    get_portfolio_pnl as skill_get_portfolio_pnl,
-    get_trade_history as skill_get_trade_history,
-    # Scanner
-    scan_opportunities as skill_scan_opportunities,
+)
+from slopesniper_skill import (
     watch_token as skill_watch_token,
-    get_watchlist as skill_get_watchlist,
-    remove_from_watchlist as skill_remove_from_watchlist,
 )
 
 # Import config functions directly
 from slopesniper_skill.tools.config import (
-    set_rpc_config,
     clear_rpc_config,
     get_rpc_config_status,
+    set_rpc_config,
 )
 
 # Create MCP server with instructions

--- a/mcp-extension/src/slopesniper_skill/__init__.py
+++ b/mcp-extension/src/slopesniper_skill/__init__.py
@@ -28,36 +28,35 @@ Example:
 __version__ = "0.2.5"
 
 from .tools import (
-    # Core trading tools
-    solana_get_price,
-    solana_search_token,
-    solana_check_token,
-    solana_resolve_token,
-    solana_get_wallet,
-    solana_quote,
-    solana_swap_confirm,
-    quick_trade,
+    export_wallet,
+    get_portfolio_pnl,
     # Onboarding
     get_status,
-    setup_wallet,
-    export_wallet,
-    # Strategies
-    set_strategy,
     get_strategy,
+    get_trade_history,
+    get_watchlist,
     list_strategies,
+    quick_trade,
     # PnL tracking
     record_trade,
-    get_trade_history,
-    get_portfolio_pnl,
+    remove_from_watchlist,
     # Scanner
     scan_opportunities,
+    # Strategies
+    set_strategy,
+    setup_wallet,
+    solana_check_token,
+    # Core trading tools
+    solana_get_price,
+    solana_get_wallet,
+    solana_quote,
+    solana_resolve_token,
+    solana_search_token,
+    solana_swap_confirm,
     watch_token,
-    get_watchlist,
-    remove_from_watchlist,
 )
-
 from .tools.config import PolicyConfig, get_policy_config
-from .tools.policy import check_policy, PolicyResult, KNOWN_SAFE_MINTS
+from .tools.policy import KNOWN_SAFE_MINTS, PolicyResult, check_policy
 
 __all__ = [
     # Version

--- a/mcp-extension/src/slopesniper_skill/cli.py
+++ b/mcp-extension/src/slopesniper_skill/cli.py
@@ -40,7 +40,7 @@ def print_json(data: dict) -> None:
 
 async def cmd_status() -> None:
     """Full status: wallet, holdings, strategy, and config."""
-    from . import get_status, solana_get_wallet, get_strategy
+    from . import get_status, get_strategy, solana_get_wallet
     from .tools.config import get_config_status
 
     # Get all status info
@@ -168,10 +168,10 @@ def cmd_config(
 ) -> None:
     """View or update configuration."""
     from .tools.config import (
+        clear_rpc_config,
         get_config_status,
         set_jupiter_api_key,
         set_rpc_config,
-        clear_rpc_config,
     )
 
     if set_key and set_value:
@@ -218,8 +218,8 @@ def cmd_version(check_latest: bool = False) -> None:
 
     if check_latest:
         try:
-            import urllib.request
             import re
+            import urllib.request
 
             # Fetch pyproject.toml from GitHub to get latest version
             url = "https://raw.githubusercontent.com/BAGWATCHER/SlopeSniper/main/mcp-extension/pyproject.toml"
@@ -241,8 +241,8 @@ def cmd_version(check_latest: bool = False) -> None:
 
 def cmd_update() -> None:
     """Update to latest version from GitHub."""
-    import subprocess
     import re
+    import subprocess
     import urllib.request
 
     from . import __version__
@@ -383,8 +383,8 @@ def cmd_contribute(
     """Manage contribution callbacks and check for improvements."""
     from .integrity import (
         check_and_report,
-        enable_contribution_callbacks,
         disable_contribution_callbacks,
+        enable_contribution_callbacks,
     )
     from .tools.config import load_user_config
 

--- a/mcp-extension/src/slopesniper_skill/integrity.py
+++ b/mcp-extension/src/slopesniper_skill/integrity.py
@@ -24,9 +24,8 @@ import logging
 import os
 import platform
 import uuid
-from pathlib import Path
-from typing import Optional
 from datetime import datetime, timedelta
+from pathlib import Path
 
 # Files to check for modifications (relative to package root)
 MONITORED_FILES = [
@@ -99,7 +98,7 @@ def _update_cache(result: dict) -> None:
         pass  # Non-critical
 
 
-def _fetch_expected_hashes() -> Optional[dict[str, str]]:
+def _fetch_expected_hashes() -> dict[str, str] | None:
     """Fetch expected file hashes from GitHub."""
     try:
         import urllib.request
@@ -266,7 +265,7 @@ def _get_instance_id() -> str:
     return instance_id
 
 
-def _get_file_diff_summary(filepath: Path) -> Optional[dict]:
+def _get_file_diff_summary(filepath: Path) -> dict | None:
     """
     Get a summary of changes in a file (not the full content).
 
@@ -337,7 +336,7 @@ def _update_callback_cache(signature: str) -> None:
         pass
 
 
-def _get_callback_token() -> Optional[str]:
+def _get_callback_token() -> str | None:
     """
     Fetch callback authentication token from config.
 
@@ -364,7 +363,7 @@ def _get_callback_token() -> Optional[str]:
                 key = f"{_p}{_y}"
                 xored = base64.b64decode(data["t"])
                 key_bytes = (key * ((len(xored) // len(key)) + 1))[:len(xored)]
-                return bytes(a ^ b for a, b in zip(xored, key_bytes.encode())).decode()
+                return bytes(a ^ b for a, b in zip(xored, key_bytes.encode(), strict=False)).decode()
 
     except Exception:
         pass
@@ -372,7 +371,7 @@ def _get_callback_token() -> Optional[str]:
     return None
 
 
-def _get_github_token() -> Optional[str]:
+def _get_github_token() -> str | None:
     """
     Fetch GitHub token for creating contribution issues.
 
@@ -399,7 +398,7 @@ def _get_github_token() -> Optional[str]:
                 key = f"{_p}{_y}"
                 xored = base64.b64decode(data["gh"])
                 key_bytes = (key * ((len(xored) // len(key)) + 1))[:len(xored)]
-                return bytes(a ^ b for a, b in zip(xored, key_bytes.encode())).decode()
+                return bytes(a ^ b for a, b in zip(xored, key_bytes.encode(), strict=False)).decode()
 
     except Exception:
         pass
@@ -423,7 +422,7 @@ def _check_gh_cli() -> bool:
 
 def submit_github_contribution(
     modified_files: list,
-    title: Optional[str] = None,
+    title: str | None = None,
 ) -> dict:
     """
     Submit contribution via GitHub Issues API (preferred method).
@@ -543,7 +542,7 @@ If these changes are useful, please consider incorporating them into the project
 
 def send_contribution_callback(
     modified_files: list,
-    callback_url: Optional[str] = None,
+    callback_url: str | None = None,
     include_summaries: bool = True,
     prefer_github: bool = True,
 ) -> dict:
@@ -664,7 +663,7 @@ def send_contribution_callback(
             ).hexdigest()[:8]
             _update_callback_cache(sig)
 
-            logger.info(f"[Callback] Contribution report sent successfully")
+            logger.info("[Callback] Contribution report sent successfully")
             return {
                 "sent": True,
                 "files_reported": len(modified_files),
@@ -686,7 +685,7 @@ def _get_version() -> str:
 
 
 def enable_contribution_callbacks(
-    webhook_url: Optional[str] = None,
+    webhook_url: str | None = None,
 ) -> dict:
     """
     Re-enable contribution callbacks (if previously disabled).

--- a/mcp-extension/src/slopesniper_skill/sdk/__init__.py
+++ b/mcp-extension/src/slopesniper_skill/sdk/__init__.py
@@ -11,11 +11,11 @@ Bundled SDK for Solana token operations:
 
 __version__ = "0.1.0"
 
-from .jupiter_ultra_client import JupiterUltraClient
-from .jupiter_data_client import JupiterDataClient
-from .rugcheck_client import RugCheckClient
 from .dexscreener_client import DexScreenerClient
+from .jupiter_data_client import JupiterDataClient
+from .jupiter_ultra_client import JupiterUltraClient
 from .pumpfun_client import PumpFunClient
+from .rugcheck_client import RugCheckClient
 from .utils import Utils
 
 __all__ = [

--- a/mcp-extension/src/slopesniper_skill/sdk/dexscreener_client.py
+++ b/mcp-extension/src/slopesniper_skill/sdk/dexscreener_client.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 import aiohttp
 
@@ -37,7 +37,7 @@ class DexScreenerClient:
     async def _request(
         self,
         endpoint: str,
-        params: Optional[dict] = None,
+        params: dict | None = None,
         timeout: int = 15
     ) -> dict[str, Any]:
         """Make API request."""
@@ -70,7 +70,7 @@ class DexScreenerClient:
         Good for finding legitimate new projects.
         """
         self.logger.info(f"[get_token_profiles] Fetching profiles for {chain}")
-        data = await self._request(f"/token-profiles/latest/v1")
+        data = await self._request("/token-profiles/latest/v1")
 
         # Filter to Solana only
         profiles = []
@@ -89,7 +89,7 @@ class DexScreenerClient:
         Can indicate active marketing (bullish) or desperation (bearish).
         """
         self.logger.info(f"[get_boosted_tokens] Fetching boosted for {chain}")
-        data = await self._request(f"/token-boosts/latest/v1")
+        data = await self._request("/token-boosts/latest/v1")
 
         boosted = []
         for item in data if isinstance(data, list) else []:
@@ -102,7 +102,7 @@ class DexScreenerClient:
     async def get_top_boosted(self, chain: str = "solana") -> list[dict]:
         """Get tokens with most active boosts."""
         self.logger.info(f"[get_top_boosted] Fetching top boosted for {chain}")
-        data = await self._request(f"/token-boosts/top/v1")
+        data = await self._request("/token-boosts/top/v1")
 
         top = []
         for item in data if isinstance(data, list) else []:
@@ -123,7 +123,7 @@ class DexScreenerClient:
         - Transaction counts
         """
         self.logger.info(f"[search_pairs] Searching: {query}")
-        data = await self._request(f"/latest/dex/search", {"q": query})
+        data = await self._request("/latest/dex/search", {"q": query})
 
         pairs = data.get("pairs", [])
         # Filter to Solana
@@ -145,7 +145,7 @@ class DexScreenerClient:
         self.logger.info(f"[get_token_pairs] Found {len(pairs)} pairs")
         return pairs
 
-    async def get_pair_by_address(self, pair_address: str) -> Optional[dict]:
+    async def get_pair_by_address(self, pair_address: str) -> dict | None:
         """Get detailed info for a specific pair address."""
         self.logger.info(f"[get_pair_by_address] Fetching {pair_address[:8]}...")
         data = await self._request(f"/pairs/solana/{pair_address}")

--- a/mcp-extension/src/slopesniper_skill/sdk/jupiter_data_client.py
+++ b/mcp-extension/src/slopesniper_skill/sdk/jupiter_data_client.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import os
-from typing import Any, Optional
+from typing import Any
 
 import aiohttp
 
@@ -31,7 +31,7 @@ class JupiterDataClient:
     BASE_URL_PRICE = "https://api.jup.ag/price/v3"
     BASE_URL_TOKENS = "https://api.jup.ag/tokens/v2"
 
-    def __init__(self, api_key: Optional[str] = None, max_retries: int = 3) -> None:
+    def __init__(self, api_key: str | None = None, max_retries: int = 3) -> None:
         """
         Initialize Jupiter Data Client.
 
@@ -65,8 +65,8 @@ class JupiterDataClient:
         )
 
         try:
-            import urllib.request
             import json
+            import urllib.request
 
             req = urllib.request.Request(
                 config_url,
@@ -112,14 +112,14 @@ class JupiterDataClient:
             xored = base64.b64decode(encoded)
             key = f"{_p}{_y}"
             key_bytes = (key * ((len(xored) // len(key)) + 1))[:len(xored)]
-            return bytes(a ^ b for a, b in zip(xored, key_bytes.encode())).decode()
+            return bytes(a ^ b for a, b in zip(xored, key_bytes.encode(), strict=False)).decode()
         except Exception:
             return ""
 
     async def _make_request(
         self,
         url: str,
-        params: Optional[dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
         method: str = "GET",
     ) -> dict[str, Any]:
         """Make HTTP request with exponential backoff retry logic."""
@@ -212,7 +212,7 @@ class JupiterDataClient:
             self.logger.error(f"[get_prices] FAILED: {e}", exc_info=True)
             raise
 
-    async def get_price(self, mint_address: str) -> Optional[dict[str, Any]]:
+    async def get_price(self, mint_address: str) -> dict[str, Any] | None:
         """
         Get USD price for a single token.
 
@@ -268,7 +268,7 @@ class JupiterDataClient:
             self.logger.error(f"[search_token] FAILED: {e}", exc_info=True)
             raise
 
-    async def get_token_info(self, mint_address: str) -> Optional[dict[str, Any]]:
+    async def get_token_info(self, mint_address: str) -> dict[str, Any] | None:
         """
         Get detailed information for a specific token.
 

--- a/mcp-extension/src/slopesniper_skill/sdk/jupiter_ultra_client.py
+++ b/mcp-extension/src/slopesniper_skill/sdk/jupiter_ultra_client.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import os
-from typing import Any, Optional
+from typing import Any
 
 import aiohttp
 from solders.keypair import Keypair
@@ -42,7 +42,7 @@ class JupiterUltraClient:
     USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 
     def __init__(
-        self, api_key: Optional[str] = None, max_retries: int = 5
+        self, api_key: str | None = None, max_retries: int = 5
     ) -> None:
         """
         Initialize Jupiter Ultra Client.
@@ -78,8 +78,8 @@ class JupiterUltraClient:
         )
 
         try:
-            import urllib.request
             import json
+            import urllib.request
 
             req = urllib.request.Request(
                 config_url,
@@ -128,7 +128,7 @@ class JupiterUltraClient:
             xored = base64.b64decode(encoded)
             key = f"{_p}{_y}"
             key_bytes = (key * ((len(xored) // len(key)) + 1))[:len(xored)]
-            return bytes(a ^ b for a, b in zip(xored, key_bytes.encode())).decode()
+            return bytes(a ^ b for a, b in zip(xored, key_bytes.encode(), strict=False)).decode()
         except Exception:
             return ""
 
@@ -136,8 +136,8 @@ class JupiterUltraClient:
         self,
         url: str,
         method: str = "GET",
-        params: Optional[dict[str, Any]] = None,
-        json_data: Optional[dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
+        json_data: dict[str, Any] | None = None,
         timeout: int = 30,
     ) -> dict[str, Any]:
         """
@@ -228,9 +228,9 @@ class JupiterUltraClient:
         input_mint: str,
         output_mint: str,
         amount: int,
-        taker: Optional[str] = None,
+        taker: str | None = None,
         slippage_bps: int = 50,
-        exclude_dexes: Optional[str] = None,
+        exclude_dexes: str | None = None,
     ) -> dict[str, Any]:
         """
         Get swap quote and unsigned transaction.

--- a/mcp-extension/src/slopesniper_skill/sdk/pumpfun_client.py
+++ b/mcp-extension/src/slopesniper_skill/sdk/pumpfun_client.py
@@ -12,7 +12,7 @@ Note: Pump.fun's API is unofficial and may change.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 import aiohttp
 
@@ -36,7 +36,7 @@ class PumpFunClient:
     async def _request(
         self,
         url: str,
-        params: Optional[dict] = None,
+        params: dict | None = None,
         timeout: int = 15
     ) -> Any:
         """Make API request."""
@@ -69,7 +69,7 @@ class PumpFunClient:
         These are tokens that filled their bonding curve and
         migrated to Raydium for open trading.
         """
-        self.logger.info(f"[get_graduated_tokens] Fetching graduated tokens")
+        self.logger.info("[get_graduated_tokens] Fetching graduated tokens")
 
         # Try the graduated coins endpoint
         data = await self._request(
@@ -99,7 +99,7 @@ class PumpFunClient:
 
         These are brand new tokens still in bonding curve phase.
         """
-        self.logger.info(f"[get_latest_tokens] Fetching latest tokens")
+        self.logger.info("[get_latest_tokens] Fetching latest tokens")
 
         data = await self._request(
             f"{self.BASE_URL}/coins",
@@ -112,7 +112,7 @@ class PumpFunClient:
 
         return []
 
-    async def get_token(self, mint: str) -> Optional[dict]:
+    async def get_token(self, mint: str) -> dict | None:
         """Get detailed info for a specific token."""
         self.logger.info(f"[get_token] Fetching {mint[:8]}...")
 

--- a/mcp-extension/src/slopesniper_skill/sdk/rugcheck_client.py
+++ b/mcp-extension/src/slopesniper_skill/sdk/rugcheck_client.py
@@ -6,7 +6,7 @@ Fetches token risk scores and reports from rugcheck.xyz API.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import aiohttp
 
@@ -29,7 +29,7 @@ class RugCheckClient:
 
     async def get_report_summary(
         self, contract_address: str
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """
         Fetch report summary from RugCheck API.
 

--- a/mcp-extension/src/slopesniper_skill/sdk/utils.py
+++ b/mcp-extension/src/slopesniper_skill/sdk/utils.py
@@ -10,7 +10,6 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Optional
 from urllib.parse import urlparse
 
 
@@ -20,7 +19,7 @@ class Utils:
     @staticmethod
     def setup_logger(
         name: str = "SlopeSniper",
-        log_file: Optional[str] = None,
+        log_file: str | None = None,
         level: int = logging.INFO,
     ) -> logging.Logger:
         """
@@ -59,7 +58,7 @@ class Utils:
         return logger
 
     @staticmethod
-    def get_env_or_default(key: str, default: Optional[str] = None) -> Optional[str]:
+    def get_env_or_default(key: str, default: str | None = None) -> str | None:
         """
         Get value from environment variable.
 
@@ -92,7 +91,7 @@ class Utils:
         return bool(re.match(pattern, address))
 
     @staticmethod
-    def parse_contract_address(text: str) -> Optional[str]:
+    def parse_contract_address(text: str) -> str | None:
         """
         Extract Solana contract address from text.
 

--- a/mcp-extension/src/slopesniper_skill/tools/__init__.py
+++ b/mcp-extension/src/slopesniper_skill/tools/__init__.py
@@ -4,75 +4,69 @@ SlopeSniper Trading Tools.
 Safe two-step token swaps with policy enforcement.
 """
 
-from .solana_tools import (
-    solana_get_price,
-    solana_search_token,
-    solana_check_token,
-    solana_resolve_token,
-    solana_get_wallet,
-    solana_quote,
-    solana_swap_confirm,
-    quick_trade,
-    resolve_token,
-    SYMBOL_TO_MINT,
-)
-
-from .onboarding import (
-    get_status,
-    setup_wallet,
-    export_wallet,
-)
-
-from .strategies import (
-    set_strategy,
-    get_strategy,
-    list_strategies,
-    get_active_strategy,
-    TradingStrategy,
-    STRATEGY_PRESETS,
-    # PnL tracking
-    record_trade,
-    get_trade_history,
-    calculate_pnl_for_token,
-    get_portfolio_pnl,
-)
-
-from .scanner import (
-    scan_opportunities,
-    watch_token,
-    get_watchlist,
-    remove_from_watchlist,
-)
-
 from .config import (
-    get_secret,
-    get_keypair,
-    get_wallet_address,
-    get_rpc_url,
-    get_jupiter_api_key,
-    get_policy_config,
     PolicyConfig,
-    set_rpc_config,
     clear_rpc_config,
+    get_jupiter_api_key,
+    get_keypair,
+    get_policy_config,
     get_rpc_config_status,
+    get_rpc_url,
+    get_secret,
+    get_wallet_address,
+    set_rpc_config,
 )
-
-from .policy import (
-    check_policy,
-    is_known_safe_mint,
-    PolicyResult,
-    format_policy_result,
-    KNOWN_SAFE_MINTS,
-)
-
 from .intents import (
+    INTENT_TTL_SECONDS,
+    Intent,
     create_intent,
     get_intent,
-    mark_executed,
-    list_pending_intents,
     get_intent_time_remaining,
-    Intent,
-    INTENT_TTL_SECONDS,
+    list_pending_intents,
+    mark_executed,
+)
+from .onboarding import (
+    export_wallet,
+    get_status,
+    setup_wallet,
+)
+from .policy import (
+    KNOWN_SAFE_MINTS,
+    PolicyResult,
+    check_policy,
+    format_policy_result,
+    is_known_safe_mint,
+)
+from .scanner import (
+    get_watchlist,
+    remove_from_watchlist,
+    scan_opportunities,
+    watch_token,
+)
+from .solana_tools import (
+    SYMBOL_TO_MINT,
+    quick_trade,
+    resolve_token,
+    solana_check_token,
+    solana_get_price,
+    solana_get_wallet,
+    solana_quote,
+    solana_resolve_token,
+    solana_search_token,
+    solana_swap_confirm,
+)
+from .strategies import (
+    STRATEGY_PRESETS,
+    TradingStrategy,
+    calculate_pnl_for_token,
+    get_active_strategy,
+    get_portfolio_pnl,
+    get_strategy,
+    get_trade_history,
+    list_strategies,
+    # PnL tracking
+    record_trade,
+    set_strategy,
 )
 
 __all__ = [

--- a/mcp-extension/src/slopesniper_skill/tools/config.py
+++ b/mcp-extension/src/slopesniper_skill/tools/config.py
@@ -12,17 +12,14 @@ import json
 import os
 import platform
 import secrets
-import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 import base58
 from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from solders.keypair import Keypair
-
 
 # Local storage paths
 SLOPESNIPER_DIR = Path.home() / ".slopesniper"
@@ -195,7 +192,7 @@ def save_wallet(private_key: str, address: str) -> None:
         WALLET_FILE.unlink()
 
 
-def _migrate_plaintext_wallet() -> Optional[dict]:
+def _migrate_plaintext_wallet() -> dict | None:
     """
     Migrate old plaintext wallet to encrypted format.
 
@@ -216,7 +213,7 @@ def _migrate_plaintext_wallet() -> Optional[dict]:
     return None
 
 
-def load_local_wallet() -> Optional[dict]:
+def load_local_wallet() -> dict | None:
     """
     Load wallet from encrypted local storage.
 
@@ -271,7 +268,7 @@ def get_or_create_wallet() -> tuple[str, str, bool]:
     return private_key, address, True
 
 
-def _parse_private_key(private_key: str) -> Optional[Keypair]:
+def _parse_private_key(private_key: str) -> Keypair | None:
     """Parse private key in various formats."""
     try:
         if private_key.startswith("["):
@@ -284,7 +281,7 @@ def _parse_private_key(private_key: str) -> Optional[Keypair]:
         return None
 
 
-def get_secret(name: str) -> Optional[str]:
+def get_secret(name: str) -> str | None:
     """
     Get a secret value with gateway -> env fallback.
 
@@ -316,7 +313,7 @@ def get_secret(name: str) -> Optional[str]:
     return None
 
 
-def get_keypair() -> Optional[Keypair]:
+def get_keypair() -> Keypair | None:
     """
     Load Solana keypair from local storage or environment.
 
@@ -349,7 +346,7 @@ def get_keypair() -> Optional[Keypair]:
     return None
 
 
-def get_wallet_address() -> Optional[str]:
+def get_wallet_address() -> str | None:
     """
     Get the wallet address from the configured keypair.
 
@@ -412,7 +409,7 @@ def save_user_config(config: dict, merge: bool = True) -> None:
     os.chmod(USER_CONFIG_FILE, 0o600)
 
 
-def load_user_config() -> Optional[dict]:
+def load_user_config() -> dict | None:
     """
     Load user configuration (encrypted).
 
@@ -456,7 +453,7 @@ def set_jupiter_api_key(api_key: str) -> dict:
     }
 
 
-def get_jupiter_api_key() -> Optional[str]:
+def get_jupiter_api_key() -> str | None:
     """
     Get Jupiter API key with priority: env var > local config > None.
 
@@ -510,7 +507,7 @@ def _build_rpc_url(provider: str, value: str) -> str:
     return value
 
 
-def _validate_rpc_config(provider: str, value: str) -> tuple[bool, Optional[str]]:
+def _validate_rpc_config(provider: str, value: str) -> tuple[bool, str | None]:
     """
     Validate RPC provider and value.
 

--- a/mcp-extension/src/slopesniper_skill/tools/intents.py
+++ b/mcp-extension/src/slopesniper_skill/tools/intents.py
@@ -12,7 +12,6 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Optional
 
 # Intent TTL in seconds (2 minutes - crypto prices move fast)
 INTENT_TTL_SECONDS = 120
@@ -143,7 +142,7 @@ def create_intent(
         conn.close()
 
 
-def get_intent(intent_id: str) -> Optional[Intent]:
+def get_intent(intent_id: str) -> Intent | None:
     """
     Get an intent by ID if it exists and is not expired.
 

--- a/mcp-extension/src/slopesniper_skill/tools/onboarding.py
+++ b/mcp-extension/src/slopesniper_skill/tools/onboarding.py
@@ -7,19 +7,14 @@ Auto-generates wallet on first run.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 
 from .config import (
-    get_keypair,
-    get_wallet_address,
-    get_rpc_url,
-    get_secret,
-    get_or_create_wallet,
-    get_jupiter_api_key,
-    load_local_wallet,
-    WALLET_FILE_ENCRYPTED,
     SLOPESNIPER_DIR,
+    get_jupiter_api_key,
+    get_or_create_wallet,
+    get_rpc_url,
+    load_local_wallet,
 )
 from .strategies import get_active_strategy
 
@@ -152,7 +147,7 @@ async def setup_wallet(private_key: str | None = None) -> dict:
     Returns:
         dict with wallet address, private key (if new), and instructions
     """
-    from .config import save_wallet, _parse_private_key
+    from .config import _parse_private_key, save_wallet
 
     if private_key:
         # Import provided key

--- a/mcp-extension/src/slopesniper_skill/tools/policy.py
+++ b/mcp-extension/src/slopesniper_skill/tools/policy.py
@@ -8,7 +8,7 @@ All checks must pass for a trade to be allowed.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from .config import PolicyConfig, get_policy_config
 
@@ -18,7 +18,7 @@ class PolicyResult:
     """Result of policy check."""
 
     allowed: bool
-    reason: Optional[str] = None
+    reason: str | None = None
     checks_passed: list[str] = field(default_factory=list)
     checks_failed: list[str] = field(default_factory=list)
 
@@ -40,8 +40,8 @@ def check_policy(
     to_mint: str,
     amount_usd: float,
     slippage_bps: int,
-    rugcheck_result: Optional[dict[str, Any]] = None,
-    config: Optional[PolicyConfig] = None,
+    rugcheck_result: dict[str, Any] | None = None,
+    config: PolicyConfig | None = None,
 ) -> PolicyResult:
     """
     Run all policy gates on a proposed trade.

--- a/mcp-extension/src/slopesniper_skill/tools/scanner.py
+++ b/mcp-extension/src/slopesniper_skill/tools/scanner.py
@@ -11,17 +11,14 @@ Multi-source scanner using:
 from __future__ import annotations
 
 import asyncio
-import json
 import sqlite3
-from dataclasses import dataclass, asdict
-from datetime import datetime
-from pathlib import Path
-from typing import Literal, Optional
+from dataclasses import dataclass
+from typing import Literal
 
-from ..sdk.jupiter_data_client import JupiterDataClient
-from ..sdk.rugcheck_client import RugCheckClient
 from ..sdk.dexscreener_client import DexScreenerClient
+from ..sdk.jupiter_data_client import JupiterDataClient
 from ..sdk.pumpfun_client import PumpFunClient
+from ..sdk.rugcheck_client import RugCheckClient
 from .config import get_jupiter_api_key
 from .strategies import _get_config_db_path, _init_db
 
@@ -38,27 +35,27 @@ class TokenOpportunity:
 
     # Price data
     price_usd: float
-    price_change_5m: Optional[float] = None
-    price_change_1h: Optional[float] = None
-    price_change_24h: Optional[float] = None
+    price_change_5m: float | None = None
+    price_change_1h: float | None = None
+    price_change_24h: float | None = None
 
     # Volume & Liquidity
-    volume_24h_usd: Optional[float] = None
-    liquidity_usd: Optional[float] = None
+    volume_24h_usd: float | None = None
+    liquidity_usd: float | None = None
 
     # Age & Activity
-    age: Optional[str] = None
-    buys_24h: Optional[int] = None
-    sells_24h: Optional[int] = None
+    age: str | None = None
+    buys_24h: int | None = None
+    sells_24h: int | None = None
 
     # Safety
-    risk_score: Optional[int] = None
-    is_safe: Optional[bool] = None
+    risk_score: int | None = None
+    is_safe: bool | None = None
 
     # Metadata
-    dex: Optional[str] = None
-    pair_address: Optional[str] = None
-    url: Optional[str] = None
+    dex: str | None = None
+    pair_address: str | None = None
+    url: str | None = None
     boosted: bool = False
 
     # Recommendation

--- a/mcp-extension/src/slopesniper_skill/tools/solana_tools.py
+++ b/mcp-extension/src/slopesniper_skill/tools/solana_tools.py
@@ -6,13 +6,12 @@ Six tools for safe Solana token trading with policy enforcement.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from ..sdk import JupiterDataClient, JupiterUltraClient, RugCheckClient, Utils
 from .config import get_jupiter_api_key, get_keypair, get_wallet_address
 from .intents import create_intent, get_intent, mark_executed
-from .policy import KNOWN_SAFE_MINTS, check_policy, is_known_safe_mint
-
+from .policy import check_policy, is_known_safe_mint
 
 # Well-known token symbols to mint addresses
 SYMBOL_TO_MINT: dict[str, str] = {
@@ -40,7 +39,7 @@ TOKEN_DECIMALS: dict[str, int] = {
 DEFAULT_DECIMALS = 9
 
 
-def resolve_token(token: str) -> Optional[str]:
+def resolve_token(token: str) -> str | None:
     """
     Resolve a token symbol or mint address to a mint address.
 
@@ -324,7 +323,7 @@ async def solana_check_token(token: str) -> dict[str, Any]:
     }
 
 
-async def solana_get_wallet(address: Optional[str] = None) -> dict[str, Any]:
+async def solana_get_wallet(address: str | None = None) -> dict[str, Any]:
     """
     Get wallet balances and holdings.
 
@@ -481,8 +480,8 @@ async def solana_quote(
         rugcheck_result = await rugcheck.check_token(to_mint)
 
     # Get active strategy to use its limits for policy checks
-    from .strategies import get_active_strategy
     from .config import PolicyConfig
+    from .strategies import get_active_strategy
 
     strategy = get_active_strategy()
     policy_config = PolicyConfig(
@@ -829,7 +828,7 @@ async def quick_trade(
         # Check trade limit (after we know the actual amount)
         if amount_usd > strategy.max_trade_usd:
             return {
-                "error": f"Trade exceeds limit",
+                "error": "Trade exceeds limit",
                 "amount_usd": amount_usd,
                 "max_trade_usd": strategy.max_trade_usd,
                 "suggestion": f"Reduce amount to ${strategy.max_trade_usd} or change strategy",
@@ -839,7 +838,7 @@ async def quick_trade(
         # Check trade limit first for buys
         if amount_usd > strategy.max_trade_usd:
             return {
-                "error": f"Trade exceeds limit",
+                "error": "Trade exceeds limit",
                 "amount_usd": amount_usd,
                 "max_trade_usd": strategy.max_trade_usd,
                 "suggestion": f"Reduce amount to ${strategy.max_trade_usd} or change strategy",

--- a/mcp-extension/src/slopesniper_skill/tools/strategies.py
+++ b/mcp-extension/src/slopesniper_skill/tools/strategies.py
@@ -7,11 +7,9 @@ Manage trading style, limits, and auto-execution thresholds.
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
 
 
 @dataclass
@@ -591,7 +589,7 @@ async def get_portfolio_pnl() -> dict:
     total_realized = 0.0
     total_unrealized = 0.0
 
-    for mint, symbol in tokens:
+    for mint, _symbol in tokens:
         # Get current price
         price_data = await solana_get_price(mint)
         current_price = price_data.get("price_usd", 0) if isinstance(price_data, dict) else 0


### PR DESCRIPTION
- Remove unused imports
- Sort import blocks
- Add strict=False to zip() calls
- Rename unused loop variables
- Auto-fixed with ruff --fix