### PR TITLE
feat: add interactive wallet setup command (v0.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-01-27
+
+### Added
+- **Interactive wallet setup** - New `slopesniper setup` command with confirmation
+  - Prompts user before creating wallet
+  - Requires typing wallet address to confirm backup
+  - Clearer private key display
+  - `--import-key` flag to import existing wallet
+- **Backup reminders** - Status shows reminder if wallet has balance and hasn't been exported
+  - Tracks wallet creation and export timestamps
+  - Reminds after 7 days without backup
+
+### Changed
+- `get_status()` now suggests using `setup` command for new users
+- `export` command records timestamp for backup reminder tracking
+
 ## [0.2.6] - 2026-01-27
 
 ### Added
@@ -122,7 +138,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.7...HEAD
+[0.2.7]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.3...v0.2.4

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-0.2.6-green.svg)](https://github.com/maddefientist/SlopeSniper/releases)
+[![Version](https://img.shields.io/badge/version-0.2.7-green.svg)](https://github.com/maddefientist/SlopeSniper/releases)
 
 [Quick Start](#-quick-start) · [Features](#-features) · [Documentation](#-documentation) · [Contributing](#-contributing)
 
@@ -49,25 +49,28 @@ SlopeSniper handles token resolution, safety checks, quotes, and execution—all
 curl -fsSL https://raw.githubusercontent.com/maddefientist/SlopeSniper/main/skills/install.sh | bash
 ```
 
-### 2. Initialize Your Wallet
+### 2. Set Up Your Wallet
 
+**Recommended: Interactive Setup**
+```bash
+slopesniper setup
+```
+This guides you through wallet creation with confirmation and ensures you save your private key.
+
+**Alternative: Quick Start**
 ```bash
 slopesniper status
 ```
+Auto-generates a wallet on first run (for advanced users/automation).
 
-On first run, SlopeSniper automatically generates a dedicated trading wallet:
-
-```
-{
-  "wallet_address": "7xK9mN2...",
-  "private_key": "4ZBCvJL...",    <-- SAVE THIS! Only shown once!
-  "IMPORTANT": "Send SOL to your wallet address to start trading"
-}
+**Import Existing Wallet**
+```bash
+slopesniper setup --import-key YOUR_PRIVATE_KEY
 ```
 
 ### 3. Fund Your Wallet
 
-Send SOL to the displayed wallet address. This is your dedicated trading wallet—only deposit what you're willing to trade.
+Send SOL to your wallet address. This is your dedicated trading wallet—only deposit what you're willing to trade.
 
 ### 4. Start Trading
 
@@ -136,6 +139,10 @@ For trades above your auto-execute threshold, you'll be asked to confirm first.
 ### CLI Reference
 
 ```bash
+# Wallet Setup (recommended for new users)
+slopesniper setup               # Interactive wallet creation with confirmation
+slopesniper setup --import-key KEY  # Import existing private key
+
 # Account & Wallet
 slopesniper status              # Full status: wallet, holdings, strategy
 slopesniper wallet              # Show wallet address and token balances
@@ -177,6 +184,11 @@ slopesniper update              # Update to latest version
 
 Your wallet is **encrypted** and stored at `~/.slopesniper/wallet.enc`. The private key is shown **only once** at creation—make sure to save it!
 
+**Create a new wallet (recommended):**
+```bash
+slopesniper setup               # Interactive setup with confirmation
+```
+
 **View wallet and holdings:**
 ```bash
 slopesniper wallet              # Quick view
@@ -189,7 +201,10 @@ slopesniper export              # Displays your private key
 ```
 
 **Import an existing wallet:**
-Set the `SOLANA_PRIVATE_KEY` environment variable before running any commands.
+```bash
+slopesniper setup --import-key YOUR_PRIVATE_KEY
+```
+Or set the `SOLANA_PRIVATE_KEY` environment variable.
 
 **Storage locations:**
 ```

--- a/mcp-extension/pyproject.toml
+++ b/mcp-extension/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slopesniper-mcp"
-version = "0.2.6"
+version = "0.2.7"
 description = "SlopeSniper MCP Server - Safe Solana Token Trading"
 requires-python = ">=3.10"
 dependencies = [

--- a/mcp-extension/src/slopesniper_skill/__init__.py
+++ b/mcp-extension/src/slopesniper_skill/__init__.py
@@ -25,7 +25,7 @@ Example:
 # Version is the single source of truth - update here for releases
 # Follow semantic versioning: MAJOR.MINOR.PATCH
 # Beta versions use 0.x.x (0.MINOR.PATCH)
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 from .tools import (
     export_wallet,

--- a/skills/slopesniper/SKILL.md
+++ b/skills/slopesniper/SKILL.md
@@ -28,12 +28,25 @@ Trade Solana meme coins and tokens using natural language. Just tell me what you
 
 ## Getting Started
 
+### New Users (Recommended)
+```bash
+slopesniper setup
+```
+Interactive setup with confirmation - guides you through wallet creation and ensures you save your private key.
+
+### Quick Start
 1. **Say "check my status"** - A wallet will be auto-generated on first run
 2. **Save your private key** - It's shown once, save it securely!
 3. **Fund your wallet** - Send SOL to the displayed address
 4. **Start trading!** Just describe what you want in plain English
 
-Optional: Set your own Jupiter API key for 10x better performance:
+### Import Existing Wallet
+```bash
+slopesniper setup --import-key YOUR_PRIVATE_KEY
+```
+
+### Optional: Faster API
+Set your own Jupiter API key for 10x better performance:
 ```bash
 slopesniper config --set-jupiter-key YOUR_KEY
 ```
@@ -100,6 +113,10 @@ For trades above your auto-execute threshold, you'll be asked to confirm first.
 Use the `slopesniper` CLI for direct execution:
 
 ```bash
+# Wallet Setup (recommended for new users)
+slopesniper setup               # Interactive wallet creation with confirmation
+slopesniper setup --import-key KEY  # Import existing private key
+
 # Account & Wallet
 slopesniper status              # Full status: wallet, holdings, strategy, config
 slopesniper wallet              # Show wallet address and all token holdings


### PR DESCRIPTION
*tips fedora* M'wallet has been secured, m'lady.

New features in this patch:
- slopesniper setup: Interactive wallet creation with explicit confirmation
- Requires typing wallet address to confirm you saved the key
- --import-key flag for importing existing wallets (backs up current)
- Backup reminder system tracks creation and export timestamps
- Shows reminder after 7 days without backup if wallet has balance
- status command now suggests setup for first-time users

The gentlesir behind the keyboard has spoken.