### PR TITLE
fix: add --quiet flag for clean JSON output (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.92] - 2026-01-27
+
+### Fixed
+- **Issue #22**: CLI logging interferes with JSON parsing in scripts
+  - Added `--quiet`/`-q` global flag to suppress logging output
+  - Clean JSON output for scripting: `slopesniper price TOKEN --quiet`
+  - Suppresses both logging and warnings from underlying libraries
+
 ## [0.2.91] - 2026-01-27
 
 ### Fixed
@@ -197,7 +205,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.8...HEAD
+[Unreleased]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.92...HEAD
+[0.2.92]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.91...v0.2.92
+[0.2.91]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.9...v0.2.91
+[0.2.9]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/BAGWATCHER/SlopeSniper/compare/v0.2.5...v0.2.6

--- a/mcp-extension/pyproject.toml
+++ b/mcp-extension/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slopesniper-mcp"
-version = "0.2.91"
+version = "0.2.92"
 description = "SlopeSniper MCP Server - Safe Solana Token Trading"
 requires-python = ">=3.10"
 dependencies = [

--- a/mcp-extension/src/slopesniper_skill/__init__.py
+++ b/mcp-extension/src/slopesniper_skill/__init__.py
@@ -25,7 +25,7 @@ Example:
 # Version is the single source of truth - update here for releases
 # Follow semantic versioning: MAJOR.MINOR.PATCH
 # Beta versions use 0.x.x (0.MINOR.PATCH)
-__version__ = "0.2.91"
+__version__ = "0.2.92"
 
 from .tools import (
     export_wallet,

--- a/mcp-extension/src/slopesniper_skill/cli.py
+++ b/mcp-extension/src/slopesniper_skill/cli.py
@@ -34,6 +34,9 @@ Usage:
     slopesniper update              Update to latest version
     slopesniper version [--check]   Show version (--check for update availability)
     slopesniper uninstall           Clean uninstall (removes CLI and optionally data)
+
+Global flags:
+    --quiet, -q                     Suppress logging output (only JSON to stdout)
 """
 
 from __future__ import annotations
@@ -794,6 +797,18 @@ def print_help() -> None:
 def main() -> None:
     """CLI entry point."""
     args = sys.argv[1:]
+
+    # Check for --quiet flag (suppresses logging for clean JSON output)
+    quiet = "--quiet" in args or "-q" in args
+    if quiet:
+        args = [a for a in args if a not in ("--quiet", "-q")]
+        import logging
+
+        logging.disable(logging.CRITICAL)
+        # Also suppress warnings from libraries
+        import warnings
+
+        warnings.filterwarnings("ignore")
 
     if not args or args[0] in ("-h", "--help", "help"):
         print_help()


### PR DESCRIPTION
ARRR matey! The CLI now lets ye silence them pesky logging messages!

- Added --quiet/-q global flag to suppress all logging
- Scripts can now parse JSON without log interference
- Warnings from landlubber libraries walk the plank too

Usage: slopesniper price TOKEN --quiet

~ Captain Quietbeard, Terror of the Noisy Seas