### PR TITLE
fix: allow GitHub issue submission without gh CLI

### DIFF
--- a/mcp-extension/src/slopesniper_skill/integrity.py
+++ b/mcp-extension/src/slopesniper_skill/integrity.py
@@ -581,8 +581,8 @@ def send_contribution_callback(
     """
     logger = logging.getLogger("SlopeSniper.Callback")
 
-    # Try GitHub first (preferred method)
-    if prefer_github and _check_gh_cli():
+    # Try GitHub first (preferred method - works with or without gh CLI)
+    if prefer_github:
         github_result = submit_github_contribution(modified_files)
         if github_result.get("submitted"):
             return github_result


### PR DESCRIPTION
Previously, send_contribution_callback() required gh CLI before trying submit_github_contribution(), but that function can work without CLI using the GitHub API with embedded PAT.

Now users without git/gh CLI can still create contribution issues via the GitHub REST API.